### PR TITLE
Limit lists by user role

### DIFF
--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -30,8 +30,27 @@ class ReportController extends Controller
 
     public function index()
     {
+        $user = Auth::user();
+        $reports = [];
+        if ($user->hasRole('admin')) {
+            $reports = Report::all();
+        }
+        else if ($user->hasRole('tutor')) {
+            foreach ($user->tutor_assignments as $assignment) {
+                foreach ($assignment->reports as $report) {
+                    array_push($reports, $report);
+                }
+            }
+        }
+        else if ($user->hasRole('professor')) {
+            foreach ($user->professor_assignments as $assignment) {
+                foreach ($assignment->reports as $report) {
+                    array_push($reports, $report);
+                }
+            }
+        }
         $data = array(
-            'reports' => Report::all()
+            'reports' => $reports
             );
         return view('reports', $data);
     }
@@ -79,10 +98,19 @@ class ReportController extends Controller
      */
     public function show($id)
     {
-        $data = array(
-            'report' => Report::find($id)
-            );
-        return view('report', $data);
+        $user = Auth::user();
+        $report = Report::find($id);
+        $assignment = $report->assignment;
+        if ($user->hasRole('admin')
+            || ($user->hasRole('tutor') && $user->id == $assignment->tutor_id)
+            || ($user->hasRole('professor') && $user->id == $assignment->professor_id))
+        {
+            $data = array(
+                'report' => Report::find($id)
+                );
+            return view('report', $data);
+        }
+        return redirect('/reports');
     }
 
     /**
@@ -93,10 +121,20 @@ class ReportController extends Controller
      */
     public function edit($id)
     {
-        $data = array(
-            'report' => Report::find($id)
-            );
-        return view('report_edit', $data);
+
+        $user = Auth::user();
+        $report = Report::find($id);
+        $assignment = $report->assignment;
+        if ($user->hasRole('admin')
+            || ($user->hasRole('tutor') && $user->id == $assignment->tutor_id)
+            || ($user->hasRole('professor') && $user->id == $assignment->professor_id))
+        {
+            $data = array(
+                'report' => Report::find($id)
+                );
+            return view('report_edit', $data);
+        }
+        return redirect('/reports');
     }
 
     /**

--- a/resources/views/assignments.blade.php
+++ b/resources/views/assignments.blade.php
@@ -8,27 +8,69 @@
                 <div class="panel-heading">Assignments</div>
 
                 <div class="panel-body">
-                    <button class="ui button" onclick="location.href='/assignment/add'">New Assignment</button>
-                    <table class="ui sortable selectable celled table">
-                        <thead>
-                            <tr>
-                                <th class="">Tutor</th>
-                                <th class="">Student</th>
-                                <th class="">Course</th>
-                                <th class="">Professor</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        @foreach ($assignments as $assignment)
-                            <tr class="clickable-row" data-href="/assignment/{{ $assignment->id }}">
-                                <td>{{ $assignment->tutor->name }}</td>
-                                <td>{{ $assignment->student->name }}</td>
-                                <td>{{ $assignment->course->department }}-{{ $assignment->course->number }} {{ $assignment->course->description }}</td>
-                                <td>{{ $assignment->professor->name }}</td>
-                            </tr>
-                        @endforeach
-                        </tbody>
-                    </table>
+                    @if (Auth::user()->hasRole('admin'))
+                        <button class="ui button" onclick="location.href='/assignment/add'">New Assignment</button>
+                        <table class="ui sortable selectable celled table">
+                            <thead>
+                                <tr>
+                                    <th class="">Tutor</th>
+                                    <th class="">Student</th>
+                                    <th class="">Course</th>
+                                    <th class="">Professor</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            @foreach ($assignments as $assignment)
+                                <tr class="clickable-row" data-href="/assignment/{{ $assignment->id }}">
+                                    <td>{{ $assignment->tutor->name }}</td>
+                                    <td>{{ $assignment->student->name }}</td>
+                                    <td>{{ $assignment->course->department }}-{{ $assignment->course->number }} {{ $assignment->course->description }}</td>
+                                    <td>{{ $assignment->professor->name }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    @endif
+                    @if (Auth::user()->hasRole('tutor'))
+                        <table class="ui sortable selectable celled table">
+                            <thead>
+                                <tr>
+                                    <th class="">Student</th>
+                                    <th class="">Course</th>
+                                    <th class="">Professor</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            @foreach ($tutor_assignments as $assignment)
+                                <tr class="clickable-row" data-href="/assignment/{{ $assignment->id }}">
+                                    <td>{{ $assignment->student->name }}</td>
+                                    <td>{{ $assignment->course->department }}-{{ $assignment->course->number }} {{ $assignment->course->description }}</td>
+                                    <td>{{ $assignment->professor->name }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    @endif
+                    @if (Auth::user()->hasRole('professor'))
+                        <table class="ui sortable selectable celled table">
+                            <thead>
+                                <tr>
+                                    <th class="">Tutor</th>
+                                    <th class="">Student</th>
+                                    <th class="">Course</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            @foreach ($professor_assignments as $assignment)
+                                <tr class="clickable-row" data-href="/assignment/{{ $assignment->id }}">
+                                    <td>{{ $assignment->tutor->name }}</td>
+                                    <td>{{ $assignment->student->name }}</td>
+                                    <td>{{ $assignment->course->department }}-{{ $assignment->course->number }} {{ $assignment->course->description }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Create separate tables for all, tutor, and professor assignment lists only viewable if the user has that role.

Limited access to view and edit pages if the user has is associated with it.

Limited access to add page to only admins.

Limited the reports that show up in the report list based on role.

Limited access to the view and edit report pages based on role.

TODO: Only admins should be able to access the edit page for assignments.
  Redirecting with improper credentials should bring the user to an Access Denied page.
