### PR TITLE
Fixed removing roles not removing course bindings

### DIFF
--- a/app/Http/Controllers/UserRoleController.php
+++ b/app/Http/Controllers/UserRoleController.php
@@ -49,6 +49,21 @@ class UserRoleController extends Controller
                     ['role_id', '=', $request->role]
                 ])
                 ->delete();
+            if ($request->role == 1) {  // Tutor
+                DB::table('available_tutors')
+                    ->where([
+                        ['user_id', '=', $request->user_id]
+                    ])
+                    ->delete();
+            }
+            if ($request->role == 2) {  // Professor
+                DB::table('current_professors')
+                    ->where([
+                        ['user_id', '=', $request->user_id]
+                    ])
+                    ->delete();
+            }
+
         }
         return Redirect::back()->with('success', 'Role has been removed from user.');
     }


### PR DESCRIPTION
Removing a user role now removes the courses they taught / tutored.
Fixes #3 
